### PR TITLE
0.1.1

### DIFF
--- a/flask_influxdb_response_log/FlaskInfluxDBResponseLog.py
+++ b/flask_influxdb_response_log/FlaskInfluxDBResponseLog.py
@@ -173,7 +173,13 @@ class FlaskInfluxDBResponseLog:
 
                 # Get response data
                 response_content_type = response.content_type
-                response_data = response.get_data(as_text=True)
+
+                try:
+                    response_data = response.get_data(as_text=True)
+                except RuntimeError:
+                    # For files that are not possible to convert as text, a RuntimeError exception is thrown
+                    response_data = ''
+
                 if response_content_type == 'application/json':
                     try:
                         response_data = json.dumps(json.loads(response_data), separators=json_separators)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='flask-influxdb-response-log',
-    version='0.1',
+    version='0.1.1',
     description='Extension to logging response from Flask applications using InfluxDB.',
     license='BSD',
     author='Aaron Estrada Poggio',


### PR DESCRIPTION
Fix in response data when files are not text convertible

There was an error when trying to convert some files into text using the response.get_data(text=True) function. This error throws a RuntimeError exception that it was not handled by the extension.